### PR TITLE
Allow translating extended cron expressions

### DIFF
--- a/src/CronTranslator.php
+++ b/src/CronTranslator.php
@@ -4,17 +4,30 @@ namespace Lorisleiva\CronTranslator;
 
 class CronTranslator
 {
+    private static $extendedMap = [
+        '@yearly' => '0 0 1 1 *',
+        '@annually' => '0 0 1 1 *',
+        '@monthly' => '0 0 1 * *',
+        '@weekly' => '0 0 * * 0',
+        '@daily' => '0 0 * * *',
+        '@hourly' => '0 * * * *'
+    ];
+
     public static function translate($cron)
     {
+        if (isset(self::$extendedMap[$cron])) {
+            $cron = self::$extendedMap[$cron];
+        }
+
         try {
             $fields = static::parseFields($cron);
             $orderedFields = static::orderFields($fields);
             $fieldsAsObject = static::getFieldsAsObject($fields);
-    
+
             $translations = array_map(function ($field) use ($fieldsAsObject) {
                 return $field->translate($fieldsAsObject);
             }, $orderedFields);
-        
+
             return ucfirst(implode(' ', array_filter($translations)));
         } catch (\Throwable $th) {
             throw new CronParsingException($cron);

--- a/tests/CronTranslatorTest.php
+++ b/tests/CronTranslatorTest.php
@@ -103,6 +103,17 @@ class CronTranslatorTest extends TestCase
     }
 
     /** @test */
+    public function it_handles_extended_cron_syntax()
+    {
+        $this->assertCronTranslateTo('Once an hour', '@hourly');
+        $this->assertCronTranslateTo('Every day at 12:00am', '@daily');
+        $this->assertCronTranslateTo('Every Sunday at 12:00am', '@weekly');
+        $this->assertCronTranslateTo('The 1st of every month at 12:00am', '@monthly');
+        $this->assertCronTranslateTo('Every year on January the 1st at 12:00am', '@yearly');
+        $this->assertCronTranslateTo('Every year on January the 1st at 12:00am', '@annually');
+    }
+
+    /** @test */
     public function it_returns_parsing_errors_when_something_goes_wrong()
     {
         $this->assertCronThrowsParsingError('I_AM_NOT_A_CRON_EXPRESSION');


### PR DESCRIPTION
Support `@hourly`, `@daily`, `@weekly`, `@monthly`, `@yearly` and `@annually`.