### PR TITLE
feat: drop support of php 7.4, add strong types

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['8.0', '8.1']
         stability: [ prefer-lowest, prefer-stable ]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }} tests

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         }
     ],
     "require": {
-        "php" : "^7.4 || ^8.0"
+        "php" : "^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^8.5.21 || ^9.5"
+        "phpunit/phpunit" : "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,7 +9,7 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd">
   <coverage processUncoveredFiles="true">
     <include>
       <directory suffix=".php">./src</directory>

--- a/src/CronExpression.php
+++ b/src/CronExpression.php
@@ -4,25 +4,31 @@ namespace Lorisleiva\CronTranslator;
 
 class CronExpression
 {
+    public string $raw;
     public MinutesField $minute;
     public HoursField $hour;
     public DaysOfMonthField $day;
     public MonthsField $month;
     public DaysOfWeekField $weekday;
+    public string $locale;
+    public bool $timeFormat24hours;
     public array $translations;
 
     /**
      * @throws CronParsingException
      * @throws TranslationFileMissingException
      */
-    public function __construct(public string $cron, public string $locale = 'en', public bool $timeFormat24hours = false)
+    public function __construct(string $cron, string $locale = 'en', bool $timeFormat24hours = false)
     {
+        $this->raw = $cron;
         $fields = explode(' ', $cron);
         $this->minute = new MinutesField($this, $fields[0]);
         $this->hour = new HoursField($this, $fields[1]);
         $this->day = new DaysOfMonthField($this, $fields[2]);
         $this->month = new MonthsField($this, $fields[3]);
         $this->weekday = new DaysOfWeekField($this, $fields[4]);
+        $this->locale = $locale;
+        $this->timeFormat24hours = $timeFormat24hours;
         $this->ensureLocaleExists();
         $this->loadTranslations();
     }

--- a/src/CronExpression.php
+++ b/src/CronExpression.php
@@ -4,7 +4,6 @@ namespace Lorisleiva\CronTranslator;
 
 class CronExpression
 {
-    public string $raw;
     public MinutesField $minute;
     public HoursField $hour;
     public DaysOfMonthField $day;
@@ -16,9 +15,8 @@ class CronExpression
      * @throws CronParsingException
      * @throws TranslationFileMissingException
      */
-    public function __construct(string $cron, public string $locale = 'en', public bool $timeFormat24hours = false)
+    public function __construct(public string $cron, public string $locale = 'en', public bool $timeFormat24hours = false)
     {
-        $this->raw = $cron;
         $fields = explode(' ', $cron);
         $this->minute = new MinutesField($this, $fields[0]);
         $this->hour = new HoursField($this, $fields[1]);

--- a/src/CronParsingException.php
+++ b/src/CronParsingException.php
@@ -6,8 +6,8 @@ use Exception;
 
 class CronParsingException extends Exception
 {
-    public function __construct($cron)
+    public function __construct(string $cron)
     {
-        parent::__construct("Failed to parse the following CRON expression: {$cron}");
+        parent::__construct("Failed to parse the following CRON expression: $cron");
     }
 }

--- a/src/CronTranslator.php
+++ b/src/CronTranslator.php
@@ -15,6 +15,9 @@ class CronTranslator
         '@hourly' => '0 * * * *'
     ];
 
+    /**
+     * @throws CronParsingException
+     */
     public static function translate(string $cron, string $locale = 'en', bool $timeFormat24hours = false): string
     {
         if (isset(self::$extendedMap[$cron])) {
@@ -25,7 +28,7 @@ class CronTranslator
             $expression = new CronExpression($cron, $locale, $timeFormat24hours);
             $orderedFields = static::orderFields($expression->getFields());
 
-            $translations = array_map(function (Field $field) {
+            $translations = array_map(static function (Field $field) {
                 return $field->translate();
             }, $orderedFields);
 
@@ -35,7 +38,7 @@ class CronTranslator
         }
     }
 
-    protected static function orderFields(array $fields)
+    protected static function orderFields(array $fields): array
     {
         // Group fields by CRON types.
         $onces = static::filterType($fields, 'Once');
@@ -69,7 +72,7 @@ class CronTranslator
 
     protected static function filterType(array $fields, ...$types): array
     {
-        return array_filter($fields, function (Field $field) use ($types) {
+        return array_filter($fields, static function (Field $field) use ($types) {
             return $field->hasType(...$types);
         });
     }

--- a/src/CronType.php
+++ b/src/CronType.php
@@ -4,7 +4,7 @@ namespace Lorisleiva\CronTranslator;
 
 class CronType
 {
-    const TYPES = [
+    public const TYPES = [
         'Every', 'Increment', 'Multiple', 'Once',
     ];
 
@@ -86,6 +86,6 @@ class CronType
 
     public function hasType(): bool
     {
-        return in_array($this->type, func_get_args());
+        return in_array($this->type, func_get_args(), true);
     }
 }

--- a/src/DaysOfMonthField.php
+++ b/src/DaysOfMonthField.php
@@ -6,7 +6,10 @@ class DaysOfMonthField extends Field
 {
     public int $position = 2;
 
-    public function translateEvery()
+    /**
+     * @throws CronParsingException
+     */
+    public function translateEvery(): string
     {
         if ($this->expression->weekday->hasType('Once')) {
             return $this->lang('days_of_week.every', [
@@ -17,7 +20,7 @@ class DaysOfMonthField extends Field
         return $this->lang('days_of_month.every');
     }
 
-    public function translateIncrement()
+    public function translateIncrement(): string
     {
         if ($this->getCount() > 1) {
             return $this->lang('days_of_month.multiple_per_increment', [
@@ -31,7 +34,7 @@ class DaysOfMonthField extends Field
         ]);
     }
 
-    public function translateMultiple()
+    public function translateMultiple(): string
     {
         return $this->lang('days_of_month.multiple_per_month', [
             'count' => $this->getCount(),
@@ -61,7 +64,7 @@ class DaysOfMonthField extends Field
         ]);
     }
 
-    public function format()
+    public function format(): string
     {
         return $this->langCountable('ordinals', $this->getValue());
     }

--- a/src/DaysOfWeekField.php
+++ b/src/DaysOfWeekField.php
@@ -6,12 +6,12 @@ class DaysOfWeekField extends Field
 {
     public int $position = 4;
 
-    public function translateEvery()
+    public function translateEvery(): string
     {
         return $this->lang('years.every');
     }
 
-    public function translateIncrement()
+    public function translateIncrement(): string
     {
         if ($this->getCount() > 1) {
             return $this->lang('days_of_week.multiple_per_increment', [
@@ -25,17 +25,20 @@ class DaysOfWeekField extends Field
         ]);
     }
 
-    public function translateMultiple()
+    public function translateMultiple(): string
     {
         return $this->lang('days_of_week.multiple_days_a_week', [
             'count' => $this->getCount(),
         ]);
     }
 
-    public function translateOnce()
+    /**
+     * @throws CronParsingException
+     */
+    public function translateOnce(): ?string
     {
         if ($this->expression->day->hasType('Every') && ! $this->expression->day->dropped) {
-            return; // DaysOfMonthField adapts to "Every Sunday".
+            return null; // DaysOfMonthField adapts to "Every Sunday".
         }
 
         return $this->lang('days_of_week.once_on_day', [
@@ -43,6 +46,9 @@ class DaysOfWeekField extends Field
         ]);
     }
 
+    /**
+     * @throws CronParsingException
+     */
     public function format(): string
     {
         $weekday = $this->getValue() === 0 ? 7 : $this->getValue();

--- a/src/Field.php
+++ b/src/Field.php
@@ -4,26 +4,27 @@ namespace Lorisleiva\CronTranslator;
 
 abstract class Field
 {
-    public CronExpression $expression;
-    public string $rawField;
     public CronType $type;
     public bool $dropped = false;
     public int $position;
 
-    public function __construct(CronExpression $expression, string $rawField)
+    /**
+     * @throws CronParsingException
+     */
+    public function __construct(public CronExpression $expression, public string $rawField)
     {
-        $this->expression = $expression;
-        $this->rawField = $rawField;
         $this->type = CronType::parse($rawField);
     }
 
-    public function translate()
+    public function translate(): ?string
     {
         $method = 'translate' . $this->type->type;
 
         if (method_exists($this, $method)) {
             return $this->{$method}();
         }
+
+        return null;
     }
 
     public function hasType(): bool
@@ -46,17 +47,17 @@ abstract class Field
         return $this->type->increment;
     }
 
-    public function getTimes()
+    public function getTimes(): array|string
     {
         return $this->langCountable('times', $this->getCount());
     }
 
-    protected function langCountable(string $key, int $value)
+    protected function langCountable(string $key, int $value): array|string
     {
         return $this->expression->langCountable($key, $value);
     }
 
-    protected function lang(string $key, array $replacements = [])
+    protected function lang(string $key, array $replacements = []): string
     {
         return $this->expression->lang($key, $replacements);
     }

--- a/src/HoursField.php
+++ b/src/HoursField.php
@@ -6,7 +6,7 @@ class HoursField extends Field
 {
     public int $position = 1;
 
-    public function translateEvery()
+    public function translateEvery(): string
     {
         if ($this->expression->minute->hasType('Once')) {
             return $this->lang('hours.once_an_hour');
@@ -15,7 +15,7 @@ class HoursField extends Field
         return $this->lang('hours.every');
     }
 
-    public function translateIncrement()
+    public function translateIncrement(): string
     {
         if ($this->expression->minute->hasType('Once')) {
             return $this->lang('hours.times_per_increment', [
@@ -42,7 +42,7 @@ class HoursField extends Field
         ]);
     }
 
-    public function translateMultiple()
+    public function translateMultiple(): string
     {
         if ($this->expression->minute->hasType('Once')) {
             return $this->lang('hours.times_per_day', [
@@ -55,7 +55,7 @@ class HoursField extends Field
         ]);
     }
 
-    public function translateOnce()
+    public function translateOnce(): string
     {
         $minute = $this->expression->minute->hasType('Once')
             ? $this->expression->minute

--- a/src/MinutesField.php
+++ b/src/MinutesField.php
@@ -6,12 +6,12 @@ class MinutesField extends Field
 {
     public int $position = 0;
 
-    public function translateEvery()
+    public function translateEvery(): string
     {
         return $this->lang('minutes.every');
     }
 
-    public function translateIncrement()
+    public function translateIncrement(): string
     {
         if ($this->getCount() > 1) {
             return $this->lang('minutes.times_per_increment', [
@@ -25,7 +25,7 @@ class MinutesField extends Field
         ]);
     }
 
-    public function translateMultiple()
+    public function translateMultiple(): string
     {
         return $this->lang('minutes.multiple', [
             'times' => $this->getTimes(),

--- a/src/MonthsField.php
+++ b/src/MonthsField.php
@@ -6,7 +6,7 @@ class MonthsField extends Field
 {
     public int $position = 3;
 
-    public function translateEvery()
+    public function translateEvery(): string
     {
         if ($this->expression->day->hasType('Once')) {
             return $this->lang('months.every_on_day', [
@@ -17,7 +17,7 @@ class MonthsField extends Field
         return $this->lang('months.every');
     }
 
-    public function translateIncrement()
+    public function translateIncrement(): string
     {
         if ($this->getCount() > 1) {
             return $this->lang('months.multiple_per_increment', [
@@ -31,14 +31,17 @@ class MonthsField extends Field
         ]);
     }
 
-    public function translateMultiple()
+    public function translateMultiple(): string
     {
         return $this->lang('months.multiple_per_year', [
             'count' => $this->getCount(),
         ]);
     }
 
-    public function translateOnce()
+    /**
+     * @throws CronParsingException
+     */
+    public function translateOnce(): string
     {
         if ($this->expression->day->hasType('Once')) {
             return $this->lang('months.once_on_day', [
@@ -55,7 +58,7 @@ class MonthsField extends Field
     /**
      * @throws CronParsingException
      */
-    public function format()
+    public function format(): string
     {
         if ($this->getValue() < 1 || $this->getValue() > 12) {
             throw new CronParsingException($this->expression->raw);

--- a/src/TranslationFileMissingException.php
+++ b/src/TranslationFileMissingException.php
@@ -6,7 +6,7 @@ use Exception;
 
 class TranslationFileMissingException extends Exception
 {
-    public function __construct($locale, $file)
+    public function __construct(string $locale, string $file)
     {
         parent::__construct("Failed to load the translation file [{$file}] from the locale [{$locale}].");
     }

--- a/tests/CronTranslatorDETest.php
+++ b/tests/CronTranslatorDETest.php
@@ -5,7 +5,7 @@ namespace Lorisleiva\CronTranslator\Tests;
 class CronTranslatorDETest extends TestCase
 {
     /** @test */
-    public function it_translates_expressions_to_german_with_alle_and_once()
+    public function it_translates_expressions_to_german_with_alle_and_once(): void
     {
         // All 32 (2^5) combinations of alle/Once.
         $this->assertCronTranslateToDE('Jede Minute', '* * * * *');
@@ -57,7 +57,7 @@ class CronTranslatorDETest extends TestCase
     }
 
     /** @test */
-    public function it_translate_expressions_to_german_with_multiple()
+    public function it_translate_expressions_to_german_with_multiple(): void
     {
         $this->assertCronTranslateToDE('Jede Minute 2 Stunden pro Tag', '* 8,18 * * *');
         $this->assertCronTranslateToDE('Jede Minute 3 Stunden pro Tag', '* 8,18,20 * * *');
@@ -73,7 +73,7 @@ class CronTranslatorDETest extends TestCase
     }
 
     /** @test */
-    public function it_translate_expressions_to_german_with_increment()
+    public function it_translate_expressions_to_german_with_increment(): void
     {
         $this->assertCronTranslateToDE('Jede 2 Minute', '*/2 * * * *');
         $this->assertCronTranslateToDE('Jede 2 Minute', '1/2 * * * *');
@@ -89,21 +89,21 @@ class CronTranslatorDETest extends TestCase
     }
 
     /** @test */
-    public function it_adds_junctions_to_certain_combinations_of_cron_types_in_german()
+    public function it_adds_junctions_to_certain_combinations_of_cron_types_in_german(): void
     {
         $this->assertCronTranslateToDE('Jede Minute alle 2 Stunden', '* */2 * * *');
         $this->assertCronTranslateToDE('Jede Minute alle 3 Stunden am 2. eines jeden Monats', '* 1/3 2 * *');
     }
 
     /** @test */
-    public function it_converts_ranges_of_one_into_once_cron_types_in_german()
+    public function it_converts_ranges_of_one_into_once_cron_types_in_german(): void
     {
         $this->assertCronTranslateToDE('Jede Minute um 8:00', '* 8-8 * * *');
         $this->assertCronTranslateToDE('Jede Minute im Januar', '* * * 1-1 *');
     }
 
     /** @test */
-    public function it_handles_extended_cron_syntax_in_german()
+    public function it_handles_extended_cron_syntax_in_german(): void
     {
         $this->assertCronTranslateToDE('Ein mal pro Stunde', '@hourly');
         $this->assertCronTranslateToDE('Jeden Tag um 0:00', '@daily');
@@ -115,7 +115,7 @@ class CronTranslatorDETest extends TestCase
 
     // TODO: missing test 'days_of_week' => 'multiple_per_increment'.
 
-    public function assertCronTranslateToDE($expected, $actual, $timeFormat24hours = true)
+    public function assertCronTranslateToDE(string $expected, string $actual, bool $timeFormat24hours = true): void
     {
         $this->assertCronTranslateTo($expected, $actual, 'de', $timeFormat24hours);
     }

--- a/tests/CronTranslatorFRTest.php
+++ b/tests/CronTranslatorFRTest.php
@@ -5,7 +5,7 @@ namespace Lorisleiva\CronTranslator\Tests;
 class CronTranslatorFRTest extends TestCase
 {
     /** @test */
-    public function it_translates_expressions_to_french()
+    public function it_translates_expressions_to_french(): void
     {
         $this->assertCronTranslateToFR('Chaque minute', '* * * * *');
         $this->assertCronTranslateToFR('Chaque minute les dimanches', '* * * * 0');
@@ -17,7 +17,7 @@ class CronTranslatorFRTest extends TestCase
         $this->assertCronTranslateToFR('4 fois par jour', '0 2,8,14,20 * * *');
     }
 
-    public function assertCronTranslateToFR($expected, $actual, $timeFormat24hours = false)
+    public function assertCronTranslateToFR(string $expected, string $actual, bool $timeFormat24hours = false): void
     {
         $this->assertCronTranslateTo($expected, $actual, 'fr', $timeFormat24hours);
     }

--- a/tests/CronTranslatorPTTest.php
+++ b/tests/CronTranslatorPTTest.php
@@ -5,7 +5,7 @@ namespace Lorisleiva\CronTranslator\Tests;
 class CronTranslatorPTTest extends TestCase
 {
     /** @test */
-    public function it_translates_expressions_to_french()
+    public function it_translates_expressions_to_french(): void
     {
         $this->assertCronTranslateToPT('Todos os minutos', '* * * * *');
         $this->assertCronTranslateToPT('Todos os minutos nas/nos Domingos', '* * * * 0');
@@ -16,7 +16,7 @@ class CronTranslatorPTTest extends TestCase
         $this->assertCronTranslateToPT('Nas/nos Terça-feiras no 2º de Fevereiro às 2:02am', '2 2 2 2 2');
     }
 
-    public function assertCronTranslateToPT($expected, $actual, $timeFormat24hours = false)
+    public function assertCronTranslateToPT(string $expected, string $actual, bool $timeFormat24hours = false): void
     {
         $this->assertCronTranslateTo($expected, $actual, 'pt', $timeFormat24hours);
     }

--- a/tests/CronTranslatorSKTest.php
+++ b/tests/CronTranslatorSKTest.php
@@ -5,7 +5,7 @@ namespace Lorisleiva\CronTranslator\Tests;
 class CronTranslatorSKTest extends TestCase
 {
     /** @test */
-    public function it_translates_expressions_with_every_and_once()
+    public function it_translates_expressions_with_every_and_once(): void
     {
         // All 32 (2^5) combinations of Every/Once.
         $this->assertCronTranslateTo('Každú minútu', '* * * * *', 'sk');
@@ -57,7 +57,7 @@ class CronTranslatorSKTest extends TestCase
     }
 
     /** @test */
-    public function it_translate_expressions_with_multiple()
+    public function it_translate_expressions_with_multiple(): void
     {
         $this->assertCronTranslateTo('Každú minútu 2 hodín za deň', '* 8,18 * * *', 'sk');
         $this->assertCronTranslateTo('Každú minútu 3 hodín za deň', '* 8,18,20 * * *', 'sk');
@@ -73,7 +73,7 @@ class CronTranslatorSKTest extends TestCase
     }
 
     /** @test */
-    public function it_translate_expressions_with_increment()
+    public function it_translate_expressions_with_increment(): void
     {
         $this->assertCronTranslateTo('Každých 2 minút', '*/2 * * * *', 'sk');
         $this->assertCronTranslateTo('Každých 2 minút', '1/2 * * * *', 'sk');
@@ -89,21 +89,21 @@ class CronTranslatorSKTest extends TestCase
     }
 
     /** @test */
-    public function it_adds_junctions_to_certain_combinations_of_cron_types()
+    public function it_adds_junctions_to_certain_combinations_of_cron_types(): void
     {
         $this->assertCronTranslateTo('Každú minútu každých 2 hodín', '* */2 * * *', 'sk');
         $this->assertCronTranslateTo('Každú minútu každých 3 hodín na každý 2. deň v mesiaci', '* 1/3 2 * *', 'sk');
     }
 
     /** @test */
-    public function it_converts_ranges_of_one_into_once_cron_types()
+    public function it_converts_ranges_of_one_into_once_cron_types(): void
     {
         $this->assertCronTranslateTo('Každú minútu o 8am', '* 8-8 * * *', 'sk');
         $this->assertCronTranslateTo('Každú minútu v mesiaci január', '* * * 1-1 *', 'sk');
     }
 
     /** @test */
-    public function it_handles_extended_cron_syntax()
+    public function it_handles_extended_cron_syntax(): void
     {
         $this->assertCronTranslateTo('Raz za hodinu', '@hourly', 'sk');
         $this->assertCronTranslateTo('Každý deň o 12:00am', '@daily', 'sk');

--- a/tests/CronTranslatorTest.php
+++ b/tests/CronTranslatorTest.php
@@ -1,11 +1,15 @@
-<?php
+<?php /** @noinspection PhpRedundantOptionalArgumentInspection */
+/** @noinspection PhpRedundantOptionalArgumentInspection */
+/** @noinspection PhpRedundantOptionalArgumentInspection */
+
+/** @noinspection PhpRedundantOptionalArgumentInspection */
 
 namespace Lorisleiva\CronTranslator\Tests;
 
 class CronTranslatorTest extends TestCase
 {
     /** @test */
-    public function it_translates_expressions_with_every_and_once()
+    public function it_translates_expressions_with_every_and_once(): void
     {
         // All 32 (2^5) combinations of Every/Once.
         $this->assertCronTranslateTo('Every minute', '* * * * *');
@@ -57,7 +61,7 @@ class CronTranslatorTest extends TestCase
     }
 
     /** @test */
-    public function it_translate_expressions_with_multiple()
+    public function it_translate_expressions_with_multiple(): void
     {
         $this->assertCronTranslateTo('Every minute 2 hours a day', '* 8,18 * * *');
         $this->assertCronTranslateTo('Every minute 3 hours a day', '* 8,18,20 * * *');
@@ -73,7 +77,7 @@ class CronTranslatorTest extends TestCase
     }
 
     /** @test */
-    public function it_translate_expressions_with_increment()
+    public function it_translate_expressions_with_increment(): void
     {
         $this->assertCronTranslateTo('Every 2 minutes', '*/2 * * * *');
         $this->assertCronTranslateTo('Every 2 minutes', '1/2 * * * *');
@@ -89,21 +93,21 @@ class CronTranslatorTest extends TestCase
     }
 
     /** @test */
-    public function it_adds_junctions_to_certain_combinations_of_cron_types()
+    public function it_adds_junctions_to_certain_combinations_of_cron_types(): void
     {
         $this->assertCronTranslateTo('Every minute of every 2 hours', '* */2 * * *');
         $this->assertCronTranslateTo('Every minute of every 3 hours on the 2nd of every month', '* 1/3 2 * *');
     }
 
     /** @test */
-    public function it_converts_ranges_of_one_into_once_cron_types()
+    public function it_converts_ranges_of_one_into_once_cron_types(): void
     {
         $this->assertCronTranslateTo('Every minute at 8am', '* 8-8 * * *');
         $this->assertCronTranslateTo('Every minute on January', '* * * 1-1 *');
     }
 
     /** @test */
-    public function it_handles_extended_cron_syntax()
+    public function it_handles_extended_cron_syntax(): void
     {
         $this->assertCronTranslateTo('Once an hour', '@hourly');
         $this->assertCronTranslateTo('Every day at 12:00am', '@daily');
@@ -114,7 +118,7 @@ class CronTranslatorTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_parsing_errors_when_something_goes_wrong()
+    public function it_returns_parsing_errors_when_something_goes_wrong(): void
     {
         $this->assertCronThrowsParsingError('I_AM_NOT_A_CRON_EXPRESSION');
         $this->assertCronThrowsParsingError('A * * * *');
@@ -126,14 +130,14 @@ class CronTranslatorTest extends TestCase
     }
 
     /** @test */
-    public function it_can_translate_in_different_languages()
+    public function it_can_translate_in_different_languages(): void
     {
         $this->assertCronTranslateTo('Chaque minute', '* * * * *', 'fr');
         $this->assertCronTranslateTo('Todos os minutos', '* * * * *', 'pt');
     }
 
     /** @test */
-    public function it_can_format_the_time_in_12_and_24_hours()
+    public function it_can_format_the_time_in_12_and_24_hours(): void
     {
         $this->assertCronTranslateTo('Every day at 10:30pm', '30 22 * * *', 'en', false);
         $this->assertCronTranslateTo('Every day at 22:30', '30 22 * * *', 'en', true);
@@ -142,7 +146,7 @@ class CronTranslatorTest extends TestCase
     }
 
     /** @test */
-    public function it_can_translate_in_different_languages_and_different_time_format()
+    public function it_can_translate_in_different_languages_and_different_time_format(): void
     {
         $this->assertCronTranslateTo('Chaque jour à 10:30pm', '30 22 * * *', 'fr', false);
         $this->assertCronTranslateTo('Chaque jour à 22:30', '30 22 * * *', 'fr', true);
@@ -154,7 +158,7 @@ class CronTranslatorTest extends TestCase
      * @skip
      * @doesNotPerformAssertions
      */
-    public function result_generator()
+    public function result_generator(): void
     {
         $this->generateCombinationsFromMatrix([
             ['*', '0', '1,2', '*/2'],

--- a/tests/CronTranslatorTest.php
+++ b/tests/CronTranslatorTest.php
@@ -1,8 +1,4 @@
 <?php /** @noinspection PhpRedundantOptionalArgumentInspection */
-/** @noinspection PhpRedundantOptionalArgumentInspection */
-/** @noinspection PhpRedundantOptionalArgumentInspection */
-
-/** @noinspection PhpRedundantOptionalArgumentInspection */
 
 namespace Lorisleiva\CronTranslator\Tests;
 

--- a/tests/CronTranslatorZHTest.php
+++ b/tests/CronTranslatorZHTest.php
@@ -5,7 +5,7 @@ namespace Lorisleiva\CronTranslator\Tests;
 class CronTranslatorZHTest extends TestCase
 {
     /** @test */
-    public function it_translates_expressions_with_every_and_once()
+    public function it_translates_expressions_with_every_and_once(): void
     {
         // All 32 (2^5) combinations of Every/Once.
         $this->assertCronTranslateTo('每分钟', '* * * * *');
@@ -57,7 +57,7 @@ class CronTranslatorZHTest extends TestCase
     }
 
     /** @test */
-    public function it_translate_expressions_with_multiple()
+    public function it_translate_expressions_with_multiple(): void
     {
         $this->assertCronTranslateTo('每分钟 每天有2小时', '* 8,18 * * *');
         $this->assertCronTranslateTo('每分钟 每天有3小时', '* 8,18,20 * * *');
@@ -73,7 +73,7 @@ class CronTranslatorZHTest extends TestCase
     }
 
     /** @test */
-    public function it_translate_expressions_with_increment()
+    public function it_translate_expressions_with_increment(): void
     {
         $this->assertCronTranslateTo('每2分钟', '*/2 * * * *');
         $this->assertCronTranslateTo('每2分钟', '1/2 * * * *');
@@ -89,21 +89,21 @@ class CronTranslatorZHTest extends TestCase
     }
 
     /** @test */
-    public function it_adds_junctions_to_certain_combinations_of_cron_types()
+    public function it_adds_junctions_to_certain_combinations_of_cron_types(): void
     {
         $this->assertCronTranslateTo('每分钟 每2小时', '* */2 * * *');
         $this->assertCronTranslateTo('每分钟 每3小时 在每月2号', '* 1/3 2 * *');
     }
 
     /** @test */
-    public function it_converts_ranges_of_one_into_once_cron_types()
+    public function it_converts_ranges_of_one_into_once_cron_types(): void
     {
         $this->assertCronTranslateTo('每分钟 在8am', '* 8-8 * * *');
         $this->assertCronTranslateTo('每分钟 在一月', '* * * 1-1 *');
     }
 
     /** @test */
-    public function it_handles_extended_cron_syntax()
+    public function it_handles_extended_cron_syntax(): void
     {
         $this->assertCronTranslateTo('每整点', '@hourly');
         $this->assertCronTranslateTo('每天 在12:00am', '@daily');
@@ -113,7 +113,7 @@ class CronTranslatorZHTest extends TestCase
         $this->assertCronTranslateTo('每年 在一月1号 在12:00am', '@annually');
     }
 
-    public function assertCronTranslateTo(string $expected, string $actual, string $locale = 'zh', bool $timeFormat24hours = false)
+    public function assertCronTranslateTo(string $expected, string $actual, string $locale = 'zh', bool $timeFormat24hours = false): void
     {
         parent::assertCronTranslateTo($expected, $actual, $locale, $timeFormat24hours);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,12 +8,12 @@ use Lorisleiva\CronTranslator\CronParsingException;
 
 class TestCase extends BaseTestCase
 {
-    public function assertCronTranslateTo(string $expected, string $actual, string $locale = 'en', bool $timeFormat24hours = false)
+    public function assertCronTranslateTo(string $expected, string $actual, string $locale = 'en', bool $timeFormat24hours = false): void
     {
         $this->assertEquals($expected, CronTranslator::translate($actual, $locale, $timeFormat24hours));
     }
 
-    public function assertCronThrowsParsingError(string $cron)
+    public function assertCronThrowsParsingError(string $cron): void
     {
         try {
             CronTranslator::translate($cron);
@@ -25,7 +25,7 @@ class TestCase extends BaseTestCase
         $this->fail("Expected CronParsingError exception for [$cron]");
     }
 
-    public function generateCombinationsFromMatrix(array $matrix, string $locale = 'en', bool $timeFormat24hours = false)
+    public function generateCombinationsFromMatrix(array $matrix, string $locale = 'en', bool $timeFormat24hours = false): void
     {
         function combinations($matrix, $acc = []): array
         {


### PR DESCRIPTION
In preparation of EOL of php 7.4 https://www.php.net/supported-versions.php

I changed some paramter-names in iterating arrays. PhpStrom nags about same paramter names.